### PR TITLE
Fix docker handling auf stopped containers

### DIFF
--- a/src/2.12.0/entrypoint.sh
+++ b/src/2.12.0/entrypoint.sh
@@ -3,10 +3,11 @@ set -e
 
 USER_ID=${LOCAL_USER_ID:-9001}
 
-echo "UID : $USER_ID"
-adduser --disabled-login --gecos 'NEST' --uid $USER_ID --home /home/nest nest
-export HOME=/home/nest
-
+if [[ ! $(id -u nest) = $USER_ID ]]; then
+	echo "UID : $USER_ID"
+	adduser --disabled-login --gecos 'NEST' --uid $USER_ID --home /home/nest nest
+	export HOME=/home/nest
+fi
 echo '. /opt/nest/bin/nest_vars.sh' >> /home/nest/.bashrc
 
 # NEST environment

--- a/src/2.14.0/entrypoint.sh
+++ b/src/2.14.0/entrypoint.sh
@@ -3,9 +3,11 @@ set -e
 
 USER_ID=${LOCAL_USER_ID:-9001}
 
-echo "UID : $USER_ID"
-adduser --disabled-login --gecos 'NEST' --uid $USER_ID --home /home/nest nest
-export HOME=/home/nest
+if [[ ! $(id -u nest) = $USER_ID ]]; then
+	echo "UID : $USER_ID"
+	adduser --disabled-login --gecos 'NEST' --uid $USER_ID --home /home/nest nest
+	export HOME=/home/nest
+fi
 
 echo '. /opt/nest/bin/nest_vars.sh' >> /home/nest/.bashrc
 

--- a/src/2.16.0/entrypoint.sh
+++ b/src/2.16.0/entrypoint.sh
@@ -3,9 +3,11 @@ set -e
 
 USER_ID=${LOCAL_USER_ID:-9001}
 
-echo "UID : $USER_ID"
-adduser --disabled-login --gecos 'NEST' --uid $USER_ID --home /home/nest nest
-export HOME=/home/nest
+if [[ ! $(id -u nest) = $USER_ID ]]; then
+	echo "UID : $USER_ID"
+	adduser --disabled-login --gecos 'NEST' --uid $USER_ID --home /home/nest nest
+	export HOME=/home/nest
+fi
 
 echo '. /opt/nest/bin/nest_vars.sh' >> /home/nest/.bashrc
 

--- a/src/2.16.0/slim/entrypoint.sh
+++ b/src/2.16.0/slim/entrypoint.sh
@@ -3,9 +3,11 @@ set -e
 
 USER_ID=${LOCAL_USER_ID:-9001}
 
-echo "UID : $USER_ID"
-adduser --disabled-login --gecos 'NEST' --uid $USER_ID --home /home/nest nest
-export HOME=/home/nest
+if [[ ! $(id -u nest) = $USER_ID ]]; then
+	echo "UID : $USER_ID"
+	adduser --disabled-login --gecos 'NEST' --uid $USER_ID --home /home/nest nest
+	export HOME=/home/nest
+fi
 
 echo '. /opt/nest/bin/nest_vars.sh' >> /home/nest/.bashrc
 

--- a/src/2.18.0/entrypoint.sh
+++ b/src/2.18.0/entrypoint.sh
@@ -3,9 +3,11 @@ set -e
 
 USER_ID=${LOCAL_USER_ID:-9001}
 
-echo "UID : $USER_ID"
-adduser --disabled-login --gecos 'NEST' --uid $USER_ID --home /home/nest nest
-export HOME=/home/nest
+if [[ ! $(id -u nest) = $USER_ID ]]; then
+	echo "UID : $USER_ID"
+	adduser --disabled-login --gecos 'NEST' --uid $USER_ID --home /home/nest nest
+	export HOME=/home/nest
+fi
 
 echo '. /opt/nest/bin/nest_vars.sh' >> /home/nest/.bashrc
 

--- a/src/2.18.0/slim/entrypoint.sh
+++ b/src/2.18.0/slim/entrypoint.sh
@@ -3,9 +3,11 @@ set -e
 
 USER_ID=${LOCAL_USER_ID:-9001}
 
-echo "UID : $USER_ID"
-adduser --disabled-login --gecos 'NEST' --uid $USER_ID --home /home/nest nest
-export HOME=/home/nest
+if [[ ! $(id -u nest) = $USER_ID ]]; then
+	echo "UID : $USER_ID"
+	adduser --disabled-login --gecos 'NEST' --uid $USER_ID --home /home/nest nest
+	export HOME=/home/nest
+fi
 
 echo '. /opt/nest/bin/nest_vars.sh' >> /home/nest/.bashrc
 

--- a/src/3.0/entrypoint.sh
+++ b/src/3.0/entrypoint.sh
@@ -3,9 +3,11 @@ set -e
 
 USER_ID=${LOCAL_USER_ID:-9001}
 
-echo "UID : $USER_ID"
-adduser --disabled-login --gecos 'NEST' --uid $USER_ID --home /home/nest nest
-export HOME=/home/nest
+if [[ ! $(id -u nest) = $USER_ID ]]; then
+	echo "UID : $USER_ID"
+	adduser --disabled-login --gecos 'NEST' --uid $USER_ID --home /home/nest nest
+	export HOME=/home/nest
+fi
 
 echo '. /opt/nest/bin/nest_vars.sh' >> /home/nest/.bashrc
 

--- a/src/latest/entrypoint.sh
+++ b/src/latest/entrypoint.sh
@@ -3,9 +3,11 @@ set -e
 
 USER_ID=${LOCAL_USER_ID:-9001}
 
-echo "UID : $USER_ID"
-adduser --disabled-login --gecos 'NEST' --uid $USER_ID --home /home/nest nest
-export HOME=/home/nest
+if [[ ! $(id -u nest) = $USER_ID ]]; then
+	echo "UID : $USER_ID"
+	adduser --disabled-login --gecos 'NEST' --uid $USER_ID --home /home/nest nest
+	export HOME=/home/nest
+fi
 
 echo '. /opt/nest/bin/nest_vars.sh' >> /home/nest/.bashrc
 


### PR DESCRIPTION
Check if user nest exits.
Stopped containers can now start again with `docker start -i my_app`.