### PR TITLE
Export environments for NEST Server

### DIFF
--- a/src/3.0/entrypoint.sh
+++ b/src/3.0/entrypoint.sh
@@ -27,7 +27,8 @@ fi
 
 if [[ "$1" = 'nest-server' ]]; then
     cd /opt/data
-    NEST_SERVER_RESTRICTION_OFF=TRUE
+    export NEST_SERVER_MODULES=nest,numpy
+    export NEST_SERVER_RESTRICTION_OFF=TRUE
     exec nest-server start -o -h 0.0.0.0 -p 5000 -u 65534
 fi
 

--- a/src/latest/entrypoint.sh
+++ b/src/latest/entrypoint.sh
@@ -27,7 +27,8 @@ fi
 
 if [[ "$1" = 'nest-server' ]]; then
     cd /opt/data
-    NEST_SERVER_RESTRICTION_OFF=TRUE
+    export NEST_SERVER_MODULES=nest,numpy
+    export NEST_SERVER_RESTRICTION_OFF=TRUE
     exec nest-server start -o -h 0.0.0.0 -p 5000 -u 65534
 fi
 


### PR DESCRIPTION
This PR fixes issue of NEST Server.
Before it starts with RestrictedPython whether the bash environment NEST_SERVER_RESTRICTION_OFF=TRUE.

Furthermore a module (numpy) was added for NEST Server.