### PR TITLE
Added NEST 3.1 with nest-desktop and Docker compose  

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+services:
+  nest-server:
+    build: ./src/3.1
+    image: nestsim/nest:3.1
+    environment:
+      - LOCAL_USER_ID=`id -u $USER`
+    ports:
+      - "5000:5000"
+    command:
+      - nest-server
+
+  nest-desktop:
+    build: ./src/3.1
+    image: nestsim/nest:3.1
+    environment:
+      - LOCAL_USER_ID=`id -u $USER`
+    ports:
+      - "8000:8000"
+    command:
+      - nest-desktop
+    depends_on:
+      - nest-server
+
+  nest-notebook:
+    build: ./src/3.1
+    image: nestsim/nest:3.1
+    volumes:
+      - .:/opt/data
+    environment:
+      - LOCAL_USER_ID=`id -u $USER`
+    ports:
+      - "8080:8080"
+    command:
+      - notebook
+
+# docker run -it --rm -e LOCAL_USER_ID=`id -u $USER` --name my_app -v $(pwd):/opt/data -p 8080:8080 nestsim/nest:"$2" notebook
+# docker run -it --rm -e LOCAL_USER_ID=`id -u $USER` -p 8000:8000 nestsim/nest:3.1 nest-desktop start

--- a/src/3.1/Dockerfile
+++ b/src/3.1/Dockerfile
@@ -1,12 +1,6 @@
 FROM buildpack-deps:focal as builder31
 LABEL maintainer="s.graber@fz-juelich.de"
 
-ARG WITH_MPI=ON
-ARG WITH_OMP=ON
-ARG WITH_GSL=ON
-#ARG WITH_MUSIC=ON
-ARG WITH_LIBNEUROSIM=OFF
-
 ENV TERM=xterm \
     TZ=Europe/Berlin \
     DEBIAN_FRONTEND=noninteractive
@@ -17,7 +11,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     cmake \
     cython3 \
     jq \
-    libboost1.67-dev \
+    libboost-filesystem-dev \
+    libboost-regex-dev \
+    libboost-wave-dev \
+    libboost-program-options-dev \
+    libboost-test-dev \
     libgomp1 \
     libgsl-dev \
     libltdl7 \
@@ -71,15 +69,6 @@ RUN wget https://github.com/INCF/MUSIC/archive/master.tar.gz && \
     cd / && \
     rm master.tar.gz
 
-# Install libneurosim
-# RUN git clone https://github.com/INCF/libneurosim.git libneurosim && \
-#    cd libneurosim && \
-#    chmod +x autogen.sh && \
-#    ./autogen.sh && \
-#    chmod +x configure && \
-#    ./configure --prefix=/opt/libneurosim-install --with-python=3 && \
-#    make && \
-#    make install
 
 # Install NEST
 RUN wget https://github.com/nest/nest-simulator/archive/refs/tags/v3.1.tar.gz && \
@@ -87,17 +76,15 @@ RUN wget https://github.com/nest/nest-simulator/archive/refs/tags/v3.1.tar.gz &&
     tar zxf v3.1.tar.gz && \
     cd  nest-build && \
     cmake -DCMAKE_INSTALL_PREFIX:PATH=/opt/nest/ \
-        # -Dwith-optimize=ON \
-        # -Dwith-warning=ON \
+        -Dwith-warning=ON \
+        -Dwith-boost=ON \
         -Dwith-ltdl=ON \
-        -Dwith-gsl=$WITH_GSL \
+        -Dwith-gsl=ON \
         -Dwith-readline=ON \
         -Dwith-python=ON \
-        -DPYTHON_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython3.8.so \
-        -DPYTHON_INCLUDE_DIR=/usr/include/python3.8 \
-        -Dwith-mpi=$WITH_MPI \
-        -Dwith-openmp=$WITH_OMP \
-        -Dwith-libneurosim=$WITH_LIBNEUROSIM \
+        -Dwith-mpi=ON \
+        -Dwith-openmp=ON \
+        -Dwith-libneurosim=OFF \
         -Dwith-music=/opt/music-install \
         ../nest-simulator-3.1 && \
     make
@@ -157,7 +144,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # cd PyNN-nest-dev && \
     # python3 setup.py install && \
     # cd .. && rm -rf PyNN-nest-dev && rm nest-dev.tar.gz
-    pip install --no-binary :all: PyNN
+    pip install --no-binary :all: PyNN && \
+    python3 -m pip install Flask  --user && \
+    python3 -m pip install Flask-cors  --user && \
+    python3 -m pip install RestrictedPython  --user && \
+    python3 -m pip install nest-desktop --user &&\
+    python3 -m pip install uwsgi --user &&\
+    python3 -m pip install jupyterlab --user
 
 COPY --from=builder31 /opt/nest /opt/nest
 COPY --from=builder31 /opt/music-install /opt/music-install
@@ -165,5 +158,5 @@ COPY --from=builder31 /opt/music-install /opt/music-install
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
-EXPOSE 5000 8080
+EXPOSE 5000 8000 8080
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/src/3.1/entrypoint.sh
+++ b/src/3.1/entrypoint.sh
@@ -15,6 +15,8 @@ export LD_LIBRARY_PATH=${MUSIC_PATH}/lib:$LD_LIBRARY_PATH
 export PATH=${MUSIC_PATH}/bin:$PATH
 export CPATH=${MUSIC_PATH}/include:$CPATH
 export PYTHONPATH=${MUSIC_PATH}/lib/python3.8/site-packages:$PYTHONPATH
+export NEST_SERVER_RESTRICTION_OFF=true
+export NEST_SERVER_MODULES=nest,numpy
 
 if [[ ! -d /opt/data ]]; then
     mkdir /opt/data
@@ -27,8 +29,12 @@ fi
 
 if [[ "$1" = 'nest-server' ]]; then
     cd /opt/data
-    NEST_SERVER_RESTRICTION_OFF=TRUE
     exec nest-server start -o -h 0.0.0.0 -p 5000 -u 65534
+fi
+
+if [[ "$1" = 'nest-desktop' ]]; then
+    cd /opt/data
+    exec /root/.local/bin/nest-desktop start
 fi
 
 if [[ "$1" = 'interactive' ]]; then

--- a/src/latest/Dockerfile
+++ b/src/latest/Dockerfile
@@ -1,12 +1,6 @@
 FROM buildpack-deps:focal as buildermaster
 LABEL maintainer="s.graber@fz-juelich.de"
 
-ARG WITH_MPI=ON
-ARG WITH_OMP=ON
-ARG WITH_GSL=ON
-#ARG WITH_MUSIC=ON
-ARG WITH_LIBNEUROSIM=OFF
-
 ENV TERM=xterm \
     TZ=Europe/Berlin \
     DEBIAN_FRONTEND=noninteractive
@@ -17,7 +11,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     cmake \
     cython3 \
     jq \
-    libboost1.67-dev \
+    libboost-filesystem-dev \
+    libboost-regex-dev \
+    libboost-wave-dev \
+    libboost-program-options-dev \
+    libboost-test-dev \
     libgomp1 \
     libgsl-dev \
     libltdl7 \
@@ -44,6 +42,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-pip \
     python3-scipy \
     python3-setuptools \
+    python3-sphinx \
     python3-statsmodels \
     python3-tk \
     python-dev \
@@ -54,7 +53,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # update-alternatives --remove-all python && \
     update-alternatives --install /usr/bin/python python /usr/bin/python3 10 && \
     update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 10 && \
-    python3 -m pip install --upgrade pip setuptools wheel
+    python3 -m pip install --upgrade pip setuptools wheel mock
 
 
 # Install music
@@ -70,42 +69,28 @@ RUN wget https://github.com/INCF/MUSIC/archive/master.tar.gz && \
     cd / && \
     rm master.tar.gz
 
-# Install libneurosim
-# RUN git clone https://github.com/INCF/libneurosim.git libneurosim && \
-#    cd libneurosim && \
-#    chmod +x autogen.sh && \
-#    ./autogen.sh && \
-#    chmod +x configure && \
-#    ./configure --prefix=/opt/libneurosim-install --with-python=3 && \
-#    make && \
-#    make install
 
 # Install NEST
-RUN git clone https://github.com/nest/nest-simulator.git && \
-  cd nest-simulator && \
-  git checkout master && \
-  python3 -m pip install -r ./extras/nest-simulator-doc-requirements.txt && \
-  cd .. && \
-  mkdir nest-build && \
-  ls -l && \
-  cd  nest-build && \
-  cmake -DCMAKE_INSTALL_PREFIX:PATH=/opt/nest/ \
-        # -Dwith-optimize=ON \
-        # -Dwith-warning=ON \
+RUN wget https://github.com/nest/nest-simulator/archive/refs/heads/master.tar.gz && \
+    mkdir nest-build && \
+    tar zxf master.tar.gz  && \
+    cd  nest-build && \
+    cmake -DCMAKE_INSTALL_PREFIX:PATH=/opt/nest/ \
+        -Dwith-warning=ON \
+        -Dwith-boost=ON \
         -Dwith-ltdl=ON \
-        -Dwith-gsl=$WITH_GSL \
+        -Dwith-gsl=ON \
         -Dwith-readline=ON \
         -Dwith-python=ON \
-        -DPYTHON_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython3.8.so \
-        -DPYTHON_INCLUDE_DIR=/usr/include/python3.8 \
-        -Dwith-mpi=$WITH_MPI \
-        -Dwith-openmp=$WITH_OMP \
-        -Dwith-libneurosim=$WITH_LIBNEUROSIM \
+        -Dwith-mpi=ON \
+        -Dwith-openmp=ON \
+        -Dwith-libneurosim=OFF \
         -Dwith-music=/opt/music-install \
-        ../nest-simulator && \
-  make && \
-  make html && \
-  make install
+        ../nest-simulator-master && \
+    make
+RUN python3 -m pip install -r ../nest-simulator-3.1/extras/nest-simulator-doc-requirements.txt && \
+        cd  nest-build && make html && make install
+
 
 ###############################################################################
 
@@ -159,7 +144,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # cd PyNN-nest-dev && \
     # python3 setup.py install && \
     # cd .. && rm -rf PyNN-nest-dev && rm nest-dev.tar.gz
-    pip install --no-binary :all: PyNN
+    pip install --no-binary :all: PyNN && \
+    python3 -m pip install Flask  --user && \
+    python3 -m pip install Flask-cors  --user && \
+    python3 -m pip install RestrictedPython  --user && \
+    python3 -m pip install nest-desktop --user &&\
+    python3 -m pip install uwsgi --user &&\
+    python3 -m pip install jupyterlab --user
 
 COPY --from=buildermaster /opt/nest /opt/nest
 COPY --from=buildermaster /opt/music-install /opt/music-install
@@ -167,5 +158,5 @@ COPY --from=buildermaster /opt/music-install /opt/music-install
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
-EXPOSE 5000 8080
+EXPOSE 5000 8000 8080
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/src/latest/Dockerfile
+++ b/src/latest/Dockerfile
@@ -88,7 +88,7 @@ RUN wget https://github.com/nest/nest-simulator/archive/refs/heads/master.tar.gz
         -Dwith-music=/opt/music-install \
         ../nest-simulator-master && \
     make
-RUN python3 -m pip install -r ../nest-simulator-3.1/extras/nest-simulator-doc-requirements.txt && \
+RUN python3 -m pip install -r ../nest-simulator-master/extras/nest-simulator-doc-requirements.txt && \
         cd  nest-build && make html && make install
 
 

--- a/src/latest/entrypoint.sh
+++ b/src/latest/entrypoint.sh
@@ -15,6 +15,8 @@ export LD_LIBRARY_PATH=${MUSIC_PATH}/lib:$LD_LIBRARY_PATH
 export PATH=${MUSIC_PATH}/bin:$PATH
 export CPATH=${MUSIC_PATH}/include:$CPATH
 export PYTHONPATH=${MUSIC_PATH}/lib/python3.8/site-packages:$PYTHONPATH
+export NEST_SERVER_RESTRICTION_OFF=true
+export NEST_SERVER_MODULES=nest,numpy
 
 if [[ ! -d /opt/data ]]; then
     mkdir /opt/data
@@ -27,9 +29,12 @@ fi
 
 if [[ "$1" = 'nest-server' ]]; then
     cd /opt/data
-    export NEST_SERVER_MODULES=nest,numpy
-    export NEST_SERVER_RESTRICTION_OFF=TRUE
     exec nest-server start -o -h 0.0.0.0 -p 5000 -u 65534
+fi
+
+if [[ "$1" = 'nest-desktop' ]]; then
+    cd /opt/data
+    exec /root/.local/bin/nest-desktop start
 fi
 
 if [[ "$1" = 'interactive' ]]; then


### PR DESCRIPTION
Docker files for NEST version 3.1 have been added to the repository.
On dockerhub now exists the image `nestsim/nest:3.1`. Use is with: 

    `docker pull nestsim/nest:3.1 `

As a new feature, `NEST desktop` now exists in the image and with `docker-compose` running in the startup directory, the various services of the NEST docker image can be easily controlled.

- `docker-compose up  nest-server` starts the NEST API server container and opens the corresponding port 5000. Test it with `curl localhost:5000/api`.

- `docker-compose up nest-desktop` starts the NEST server and the NEST desktop web interface. Port 8000 is also made available. Open in the web browser: `http://localhost:8000`

- `docker-compose up nest-notebook` starts a notebook server with pre-installed NEST 3.1. The corresponding URL is displayed in the console.

- `docker-compose up` starts everything

Heads up. If the docker image is not pre-installed (docker pull nestsim/nest:3.1), "docker-compose ..." will start building the docker image from the local Docker files.

The latest image has also been updated with the new features.
