### PR TITLE
Replace uwsgi to gunicorn

### DIFF
--- a/src/base/Dockerfile-deploy-base
+++ b/src/base/Dockerfile-deploy-base
@@ -43,14 +43,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         python3-pandas \
         python3-sympy \
         python3-tk \
-        uwsgi \
         wget && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/* && \
     update-alternatives --install /usr/bin/python python /usr/bin/python3 10 && \
     update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 10 && \
     python3 -m pip install quantities lazyarray neo && \
-    python3 -m pip install uwsgi && \
     # wget https://github.com/NeuralEnsemble/PyNN/archive/nest-dev.tar.gz && \
     # tar -xzf nest-dev.tar.gz && \
     # cd PyNN-nest-dev && \
@@ -61,7 +59,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 -m pip install Flask-cors --user && \
     python3 -m pip install RestrictedPython --user && \
     python3 -m pip install nest-desktop --user && \
-    python3 -m pip install uwsgi --user && \
+    python3 -m pip install gunicorn --user && \
     python3 -m pip install jupyterlab --user && \
     python3 -m pip install elephant[extras] --user && \
     python3 -m pip install nestml --pre


### PR DESCRIPTION
Since PR https://github.com/nest/nest-simulator/pull/2284 and in NEST 3.3, [gunicorn](https://docs.gunicorn.org/en/stable/install.html) is needed to start NEST Server.

Please check whether uwsgi is not needed elsewhere.