### PR TITLE
Add NESTML support to Docker images

### DIFF
--- a/src/base/Dockerfile-build-base
+++ b/src/base/Dockerfile-build-base
@@ -11,21 +11,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     cmake \
     cython3 \
     jq \
-    libboost-filesystem-dev \
-    libboost-regex-dev \
-    libboost-wave-dev \
-    libboost-program-options-dev \
-    libboost-test-dev \
+    libboost-dev \
     libgomp1 \
     libgsl-dev \
     libltdl7 \
     libltdl-dev \
     libmusic1v5 \
+    libncurses-dev \
     libopenmpi-dev \
     libomp-dev \
     libpcre3 \
     libpcre3-dev \
     libpython3.8 \
+    libreadline-dev \
     llvm-dev \
     openmpi-bin \
     pandoc \
@@ -48,8 +46,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python-dev \
     vera++ \
     wget && \
-    apt-get autoremove -y && \
-    rm -rf /var/lib/apt/lists/* && \
     # update-alternatives --remove-all python && \
     update-alternatives --install /usr/bin/python python /usr/bin/python3 10 && \
     update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 10 && \

--- a/src/base/Dockerfile-deploy-base
+++ b/src/base/Dockerfile-deploy-base
@@ -11,19 +11,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
         libpcre3 \
         libpcre3-dev \
-        libboost-filesystem-dev \
-        libboost-regex-dev \
-        libboost-wave-dev \
-        libboost-program-options-dev \
-        libboost-test-dev \
+        libboost-dev \
         gosu \
         less \
         libgomp1 \
         libgsl-dev  \
         libltdl7 \
+        libncurses-dev \
         libopenmpi-dev \
         libomp-dev \
         libpython3.8 \
+        libreadline-dev \
         nano \
         openmpi-bin \
         openssh-client \
@@ -44,8 +42,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         python3-tk \
         uwsgi \
         wget && \
-    apt-get autoremove -y && \
-    rm -rf /var/lib/apt/lists/* && \
     update-alternatives --install /usr/bin/python python /usr/bin/python3 10 && \
     update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 10 && \
     python3 -m pip install jupyter notebook --user && \

--- a/src/dev/Dockerfile
+++ b/src/dev/Dockerfile
@@ -4,11 +4,12 @@ LABEL maintainer="s.graber@fz-juelich.de"
 ARG NEST_VERSION=master
 ARG SRC_PATH=/tmp
 
-# Install NEST
+# Install NEST and NESTML
 RUN wget https://github.com/nest/nest-simulator/archive/refs/heads/${NEST_VERSION}.tar.gz -P ${SRC_PATH} && \
     cd ${SRC_PATH} && tar -xzf ${NEST_VERSION}.tar.gz && ls -l && \
     python3 -m pip install -r ${SRC_PATH}/nest-simulator-${NEST_VERSION}/doc/requirements.txt && \
     python3 -m pip install MarkupSafe==2.0.1
+    python3 -m pip install https://github.com/nest/nestml/archive/refs/heads/master.zip --upgrade
 
 RUN mkdir nest-build && cd nest-build && \
     cmake -DCMAKE_INSTALL_PREFIX:PATH=/opt/nest \


### PR DESCRIPTION
NESTML needs to have cmake, ncurses, readline etc. available within the Docker image.

Additionally, always make sure to install NESTML-master in the "latest" Docker image.