### PR TITLE
Set `-j $(nproc)` for make command

### DIFF
--- a/src/3.3/Dockerfile
+++ b/src/3.3/Dockerfile
@@ -26,7 +26,7 @@ RUN mkdir nest-build && cd nest-build && \
           -Dwith-libneurosim=OFF \
           -Dwith-music=/opt/music-install \
           ${SRC_PATH}/nest-simulator-${NEST_VERSION} && \
-    make -j 8  && \
+    make -j $(nproc) && \
     make html && \
     make install
 


### PR DESCRIPTION
It can determine the maximum number of processes for the compilation.

See https://unix.stackexchange.com/questions/208568/how-to-determine-the-maximum-number-to-pass-to-make-j-option
