### PR TITLE
Change default port for NEST Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You can use the docker images direct out of docker-registry.ebrains.eu like this
 
 TAG is '2.20.2', '3.2', '3.3' or 'dev'.
 
-#### NEST 2.20.2 
+#### NEST 2.20.2
 
 Jupyter notebook with NEST 2.20.2:
 
@@ -45,18 +45,18 @@ To use 'docker-compose' you need the definition file from the git repository. Do
 
   or
 
-      docker run -it --rm -e NEST_CONTAINER_MODE=nest-server -p 5000:5000 \
+      docker run -it --rm -e NEST_CONTAINER_MODE=nest-server -p 52425:52425 \
            docker-registry.ebrains.eu/nest/nest-simulator:3.3   
-    
-  Starts the NEST API server container and opens the corresponding port 5000. Test it with `curl localhost:5000/api`.
+
+  Starts the NEST API server container and opens the corresponding port 52425. Test it with `curl localhost:52425/api`.
 
 - NEST desktop
 
       docker-compose up nest-desktop
-  
+
   or
 
-      docker run -it --rm -e NEST_CONTAINER_MODE=nest-server -p 5000:5000 \
+      docker run -it --rm -e NEST_CONTAINER_MODE=nest-server -p 52425:52425 \
           docker-registry.ebrains.eu/nest/nest-simulator:3.3
       docker run -it --rm -e LOCAL_USER_ID=`id -u $USER` -p 8000:8000  \
           -e NEST_CONTAINER_MODE=nest-desktop docker-registry.ebrains.eu/nest/nest-simulator:3.3
@@ -72,7 +72,7 @@ To use 'docker-compose' you need the definition file from the git repository. Do
 
       docker run -it --rm -e LOCAL_USER_ID=`id -u $USER` -v $(pwd):/opt/data -e NEST_CONTAINER_MODE=notebook \
           -p 8080:8080 docker-registry.ebrains.eu/nest/nest-simulator:3.3
-    
+
   Starts a notebook server with pre-installed NEST 3.3. The corresponding URL is displayed in the console.
 
 - Jupyter lab with NEST
@@ -83,7 +83,7 @@ To use 'docker-compose' you need the definition file from the git repository. Do
 
       docker run -it --rm -e LOCAL_USER_ID=`id -u $USER` -v $(pwd):/opt/data -e NEST_CONTAINER_MODE=jupyterlab \
           -p 8080:8080 docker-registry.ebrains.eu/nest/nest-simulator:3.3
-    
+
   Starts a jupyter lab server with pre-installed NEST 3.3. The corresponding URL is displayed in the console.
 
 To stop and delete running containers use `docker-compose down`.
@@ -189,7 +189,7 @@ In the folder with your music scripts run:
                docker-registry.ebrains.eu/nest/nest-simulator:3.3 /bin/bash
 
 You are now on container's shell.
-    
+
     cd /opt/nest/share/doc/nest/examples/music/
     mpirun --allow-run-as-root -np 2 music ./minimalmusicsetup.music
 
@@ -206,7 +206,7 @@ You are now on container's shell.
 -   Import a docker image
 
         gunzip -c nest-docker.tar.gz | docker load
-       
+
 -   Execute an interactive bash shell on a running container.
 
         docker exec -it <nest_container_name> bash
@@ -219,5 +219,5 @@ You are now on container's shell.
 
     docker login docker-registry.ebrains.eu
     docker build -t nest-simulator:<VERSION> /path/to/recipe --squash
-    docker tag nest/nest-simulator:<VERSION>  docker-registry.ebrains.eu/nest/nest-simulator:<VERSION> 
-    docker push docker-registry.ebrains.eu/nest/nest-simulator:<VERSION> 
+    docker tag nest/nest-simulator:<VERSION>  docker-registry.ebrains.eu/nest/nest-simulator:<VERSION>
+    docker push docker-registry.ebrains.eu/nest/nest-simulator:<VERSION>

--- a/ci-templates/000_dev.gitlab-ci.yml
+++ b/ci-templates/000_dev.gitlab-ci.yml
@@ -7,9 +7,9 @@ Build_Dev:
   needs: ["Build_Base"]
   script:
     - docker pull $DOCKER_REGISTRY_IMAGE:dev || true
-    - docker build 
+    - docker build
         --cache-from $DOCKER_REGISTRY_IMAGE:dev
-        --tag $DOCKER_REGISTRY_IMAGE:dev.$CI_PIPELINE_ID 
+        --tag $DOCKER_REGISTRY_IMAGE:dev.$CI_PIPELINE_ID
         ./src/dev
     - docker push $DOCKER_REGISTRY_IMAGE:dev.$CI_PIPELINE_ID
   tags:
@@ -23,7 +23,7 @@ Test_Dev:
     - docker stop $(docker ps -q) 2>/dev/null || true
     - docker rm -f $(docker ps -aq) 2>/dev/null || true
     - docker ps
-    - docker run -i -d --rm -e NEST_CONTAINER_MODE=nest-server -p 5000:5000
+    - docker run -i -d --rm -e NEST_CONTAINER_MODE=nest-server -p 52425:52425
         --name $CI_PIPELINE_ID $DOCKER_REGISTRY_IMAGE:dev.$CI_PIPELINE_ID
     - docker ps
   tags:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -7,7 +7,7 @@ services:
       LOCAL_USER_ID: "`id -u $USER`"
       NEST_CONTAINER_MODE: "nest-server"
     ports:
-      - "5000:5000"
+      - "52425:52425"
 
   nest-desktop:
     image: docker-registry.ebrains.eu/nest/nest-simulator:dev

--- a/src/dev/Dockerfile
+++ b/src/dev/Dockerfile
@@ -45,5 +45,5 @@ RUN python3 -m pip install --upgrade pip && \
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
-EXPOSE 5000 8000 8080
+EXPOSE 8000 8080 52425
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/src/dev/entrypoint.sh
+++ b/src/dev/entrypoint.sh
@@ -37,7 +37,7 @@ elif [[ "${MODE}" = 'nest-desktop' ]]; then
 elif [[ "${MODE}" = 'nest-server' ]]; then
     export NEST_SERVER_HOST="${NEST_SERVER_HOST:-0.0.0.0}"
     export NEST_SERVER_MODULES="${NEST_SERVER_MODULES:-nest,numpy}"
-    export NEST_SERVER_PORT="${NEST_SERVER_PORT:-5000}"
+    export NEST_SERVER_PORT="${NEST_SERVER_PORT:-52425}"
     export NEST_SERVER_RESTRICTION_OFF="${NEST_SERVER_RESTRICTION_OFF:-1}"
     export NEST_SERVER_STDOUT="${NEST_SERVER_STDOUT:-1}"
     exec nest-server start


### PR DESCRIPTION
According to the discussion in the issue [#2321](https://github.com/nest/nest-simulator/issues/2321), the port 5000 seems having conflicts with other services. 
Thus we decided that the default port for NEST Server is now 52425.

Please review this PR after the merged PR [#2505](https://github.com/nest/nest-simulator/pull/2505) in NEST Simulator.