### PR TITLE
Change default ports and minor changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To use 'docker-compose' you need the definition file from the git repository. Do
 
     wget https://raw.githubusercontent.com/steffengraber/nest-docker/master/docker-compose.yml
 
-- NEST server
+- NEST Server
 
       docker-compose up nest-server
 
@@ -50,7 +50,7 @@ To use 'docker-compose' you need the definition file from the git repository. Do
 
   Starts the NEST API server container and opens the corresponding port 52425. Test it with `curl localhost:52425/api`.
 
-- NEST desktop
+- NEST Desktop
 
       docker-compose up nest-desktop
 
@@ -58,11 +58,11 @@ To use 'docker-compose' you need the definition file from the git repository. Do
 
       docker run -it --rm -e NEST_CONTAINER_MODE=nest-server -p 52425:52425 \
           docker-registry.ebrains.eu/nest/nest-simulator:3.3
-      docker run -it --rm -e LOCAL_USER_ID=`id -u $USER` -p 8000:8000  \
+      docker run -it --rm -e LOCAL_USER_ID=`id -u $USER` -p 54286:54286  \
           -e NEST_CONTAINER_MODE=nest-desktop docker-registry.ebrains.eu/nest/nest-simulator:3.3
 
-  Starts the NEST server and the NEST desktop web interface. Port 8000 is also made available.
-  Open in the web browser: `http://localhost:8000`
+  Starts the NEST server and the NEST desktop web interface. Port 54286 is also made available.
+  Open in the web browser: `http://localhost:54286`
 
 - Jupyter notebook with NEST
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -15,7 +15,7 @@ services:
       LOCAL_USER_ID: "`id -u $USER`"
       NEST_CONTAINER_MODE: "nest-desktop"
     ports:
-      - "8000:8000"
+      - "54286:54286"
     depends_on:
       - nest-server
 

--- a/src/3.0/Dockerfile
+++ b/src/3.0/Dockerfile
@@ -156,7 +156,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     update-alternatives --install /usr/bin/python python /usr/bin/python3 10 && \
     update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 10 && \
     pip install quantities lazyarray neo  && \
-    pip install uwsgi &&\
+    pip install uwsgi && \
+    pip install nest-desktop==3.0.* && \
     # wget https://github.com/NeuralEnsemble/PyNN/archive/nest-dev.tar.gz && \
     # tar -xzf nest-dev.tar.gz && \
     # cd PyNN-nest-dev && \

--- a/src/3.1/Dockerfile
+++ b/src/3.1/Dockerfile
@@ -147,7 +147,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 -m pip install Flask  --user && \
     python3 -m pip install Flask-cors  --user && \
     python3 -m pip install RestrictedPython  --user && \
-    python3 -m pip install nest-desktop --user && \
+    python3 -m pip install nest-desktop==3.0.* --user && \
     python3 -m pip install uwsgi --user && \
     python3 -m pip install jupyterlab --user && \
     python3 -m pip install nestml --user

--- a/src/3.2/Dockerfile
+++ b/src/3.2/Dockerfile
@@ -46,6 +46,7 @@ COPY --from=builder /opt/nest /opt/nest
 COPY --from=builder /opt/music-install /opt/music-install
 
 RUN python3 -m pip install --upgrade pip && \
+    python3 -m pip install nest-desktop==3.1.* && \
     python3 -m pip install uwsgi
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh

--- a/src/3.2/entrypoint.sh
+++ b/src/3.2/entrypoint.sh
@@ -30,7 +30,7 @@ elif [[ "${MODE}" = 'jupyterlab' ]]; then
     exec /usr/local/bin/jupyter-lab --ip="${IP_ADDRESS}" --port=8080 --no-browser --allow-root
 
 elif [[ "${MODE}" = 'nest-desktop' ]]; then
-    exec /usr/local/bin/nest-desktop start -h 0.0.0.0 -p 8000
+    exec nest-desktop start -h 0.0.0.0 -p 8000
 
 elif [[ "${MODE}" = 'nest-server' ]]; then
     export NEST_SERVER_BUFFER_SIZE="${NEST_SERVER_BUFFER_SIZE:-65535}"

--- a/src/3.3/Dockerfile
+++ b/src/3.3/Dockerfile
@@ -41,7 +41,8 @@ COPY --from=builder /opt/nest /opt/nest
 COPY --from=builder /opt/music-install /opt/music-install
 
 RUN python3 -m pip install --upgrade pip && \
-    python3 -m pip uninstall nestml -y && \
+    python3 -m pip install nest-desktop==3.1.* && \
+    python3 -m pip uninstall nestml -y && \ 
     python3 -m pip install nestml --pre --upgrade
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh

--- a/src/3.3/entrypoint.sh
+++ b/src/3.3/entrypoint.sh
@@ -33,7 +33,7 @@ elif [[ "${MODE}" = 'jupyterlab' ]]; then
 elif [[ "${MODE}" = 'nest-desktop' ]]; then
     export NEST_DESKTOP_HOST="${NEST_DESKTOP_HOST:-0.0.0.0}"
     export NEST_DESKTOP_PORT="${NEST_DESKTOP_PORT:-8000}"
-    exec /usr/local/bin/nest-desktop start
+    exec nest-desktop start
 
 elif [[ "${MODE}" = 'nest-server' ]]; then
     export NEST_SERVER_HOST="${NEST_SERVER_HOST:-0.0.0.0}"

--- a/src/3.4_rc1/Dockerfile
+++ b/src/3.4_rc1/Dockerfile
@@ -40,11 +40,12 @@ COPY --from=builder /opt/nest /opt/nest
 COPY --from=builder /opt/music-install /opt/music-install
 
 RUN python3 -m pip install --upgrade pip && \
+    python3 -m pip install nest-desktop==3.2.* --pre && \
     python3 -m pip uninstall nestml -y && \
     python3 -m pip install https://github.com/nest/nestml/archive/refs/heads/master.zip --upgrade
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
-EXPOSE 8000 8080 52425
+EXPOSE 8080 52425 54286
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/src/3.4_rc1/entrypoint.sh
+++ b/src/3.4_rc1/entrypoint.sh
@@ -31,8 +31,8 @@ elif [[ "${MODE}" = 'jupyterlab' ]]; then
 
 elif [[ "${MODE}" = 'nest-desktop' ]]; then
     export NEST_DESKTOP_HOST="${NEST_DESKTOP_HOST:-0.0.0.0}"
-    export NEST_DESKTOP_PORT="${NEST_DESKTOP_PORT:-8000}"
-    exec /usr/local/bin/nest-desktop start
+    export NEST_DESKTOP_PORT="${NEST_DESKTOP_PORT:-54286}"
+    exec nest-desktop start
 
 elif [[ "${MODE}" = 'nest-server' ]]; then
     export NEST_SERVER_HOST="${NEST_SERVER_HOST:-0.0.0.0}"

--- a/src/base/Dockerfile-deploy-base
+++ b/src/base/Dockerfile-deploy-base
@@ -51,7 +51,6 @@ RUN apt-get update && apt autoremove && apt autoclean && apt-get install -y --no
     python3 -m pip install Flask --upgrade && \
     python3 -m pip install Flask-cors --upgrade && \
     python3 -m pip install RestrictedPython --upgrade && \
-    python3 -m pip install nest-desktop && \
     python3 -m pip install MarkupSafe==2.0.1 && \
     python3 -m pip install gunicorn && \
     python3 -m pip install jupyterlab && \

--- a/src/dev/Dockerfile
+++ b/src/dev/Dockerfile
@@ -40,11 +40,12 @@ COPY --from=builder /opt/nest /opt/nest
 COPY --from=builder /opt/music-install /opt/music-install
 
 RUN python3 -m pip install --upgrade pip && \
+    python3 -m pip install nest-desktop --pre && \
     python3 -m pip uninstall nestml -y && \
     python3 -m pip install https://github.com/nest/nestml/archive/refs/heads/master.zip --upgrade
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
-EXPOSE 8000 8080 52425
+EXPOSE 8080 52425 54286
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/src/dev/entrypoint.sh
+++ b/src/dev/entrypoint.sh
@@ -31,8 +31,8 @@ elif [[ "${MODE}" = 'jupyterlab' ]]; then
 
 elif [[ "${MODE}" = 'nest-desktop' ]]; then
     export NEST_DESKTOP_HOST="${NEST_DESKTOP_HOST:-0.0.0.0}"
-    export NEST_DESKTOP_PORT="${NEST_DESKTOP_PORT:-8000}"
-    exec /usr/local/bin/nest-desktop start
+    export NEST_DESKTOP_PORT="${NEST_DESKTOP_PORT:-54286}"
+    exec nest-desktop start
 
 elif [[ "${MODE}" = 'nest-server' ]]; then
     export NEST_SERVER_HOST="${NEST_SERVER_HOST:-0.0.0.0}"


### PR DESCRIPTION
This PR includes several changes:

- Change default port of NEST Desktop to 54286
- Install specific version of NEST Desktop for various images
- Start NEST Desktop just with `nest-desktop`
- Correct some phrases