### PR TITLE
Add testing of docker container

### DIFF
--- a/ci-templates/000_3.4_rc1.gitlab-ci.yml
+++ b/ci-templates/000_3.4_rc1.gitlab-ci.yml
@@ -25,6 +25,7 @@ Test_34:
     - docker ps
     - docker run -i -d --rm -e NEST_CONTAINER_MODE=nest-server -p 52425:52425
         --name $CI_PIPELINE_ID $DOCKER_REGISTRY_IMAGE:3.4_rc1.$CI_PIPELINE_ID
+    - docker run -i --rm $CI_PIPELINE_ID $DOCKER_REGISTRY_IMAGE:3.4_rc1.$CI_PIPELINE_ID bash /opt/test.sh
     - docker ps
   tags:
     - shell-runner

--- a/src/3.4_rc1/test-nest.sh
+++ b/src/3.4_rc1/test-nest.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# run mpiexec as root
+export OMPI_ALLOW_RUN_AS_ROOT=1
+export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+
+# install what is needed
+pip3 install pytest-xdist pytest-timeout junitparser
+
+
+cd /opt/nest/share/nest/testsuite/
+bash do_tests.sh --prefix=/opt/nest --report-dir=/opt/reports --with-python=/usr/bin/python

--- a/src/dev/Dockerfile
+++ b/src/dev/Dockerfile
@@ -47,5 +47,8 @@ RUN python3 -m pip install --upgrade pip && \
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
+COPY test-nest.sh /opt/test-nest.sh
+RUN chmod +x /opt/test-nest.sh
+
 EXPOSE 8080 52425 54286
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
The testing of the NEST installation in our Docker container at run time has been missing until now. This is a first attempt.