### PR TITLE
Remove pre

### DIFF
--- a/src/3.4/Dockerfile
+++ b/src/3.4/Dockerfile
@@ -40,7 +40,7 @@ COPY --from=builder /opt/nest /opt/nest
 COPY --from=builder /opt/music-install /opt/music-install
 
 RUN python3 -m pip install --upgrade pip && \
-    python3 -m pip install nest-desktop==3.2.* --pre && \
+    python3 -m pip install nest-desktop==3.2.* && \
     python3 -m pip uninstall nestml -y && \
     python3 -m pip install https://github.com/nest/nestml/archive/refs/heads/master.zip --upgrade
 


### PR DESCRIPTION
Yesterday NEST Desktop is released, also on PYPI.
Thus it is not necessary to install pre-release.