### PR TITLE
Correct ports in docker-compose config file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       LOCAL_USER_ID: "`id -u $USER`"
       NEST_CONTAINER_MODE: "nest-server"
     ports:
-      - "5000:5000"
+      - "52425:52425"
 
   nest-desktop:
     image: nestsim/nest:3.4
@@ -15,7 +15,7 @@ services:
       LOCAL_USER_ID: "`id -u $USER`"
       NEST_CONTAINER_MODE: "nest-desktop"
     ports:
-      - "8000:8000"
+      - "54286:54286"
     depends_on:
       - nest-server
 


### PR DESCRIPTION
Since NEST 3.4 ports for NEST Server and NEST Desktop are changed.